### PR TITLE
Changes ruby-jwt decode call args to match version 2.2.1

### DIFF
--- a/discourse-omniauth-jwt.gemspec
+++ b/discourse-omniauth-jwt.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "rack-test"
   
-  spec.add_dependency "jwt"
+  spec.add_dependency "jwt", "~> 2.2.1"
   spec.add_dependency "omniauth", "~> 1.1"
 end

--- a/lib/omniauth/strategies/jwt.rb
+++ b/lib/omniauth/strategies/jwt.rb
@@ -23,7 +23,7 @@ module OmniAuth
       end
       
       def decoded
-        @decoded ||= ::JWT.decode(request.params['jwt'], options.secret, options.algorithm)[0]
+        @decoded ||= ::JWT.decode(request.params['jwt'], options.secret, true, { algorithm: options.algorithm })[0]
         (options.required_claims || []).each do |field|
           raise ClaimInvalid.new("Missing required '#{field}' claim.") if !@decoded.key?(field.to_s)
         end


### PR DESCRIPTION
The args do not match the existing jwt decode function

discourse-omniauth-jwt - lib/omniauth/strategies/jwt.rb:
```@decoded ||= ::JWT.decode(request.params['jwt'], options.secret, options.algorithm)[0]```

ruby-jwt - lib/jwt.rb:
```def decode(jwt, key = nil, verify = true, options = {}, &keyfinder)```

Maybe jwt should have been version bound.